### PR TITLE
Epic 3.2: User Discovery & Search

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1980,6 +1980,103 @@
           "Comment"
         ]
       }
+    },
+    "/api/v1/search/all": {
+      "get": {
+        "operationId": "SearchController_searchAll_v1",
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "description": "Từ khóa tìm kiếm",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Trang",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Số lượng trên mỗi trang",
+            "schema": {
+              "default": 10,
+              "example": 10,
+              "type": "number"
+            }
+          },
+          {
+            "name": "timeRange",
+            "required": false,
+            "in": "query",
+            "description": "Khoảng thời gian (7d, 30d, 90d, all)",
+            "schema": {
+              "example": "7d",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Kết quả tìm kiếm",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedSearchResultDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Tìm kiếm tất cả các loại (user, post, event, ...)",
+        "tags": [
+          "Search"
+        ]
+      }
+    },
+    "/api/v1/search": {
+      "post": {
+        "operationId": "SearchController_search_v1",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "description": "Body chứa các tham số tìm kiếm",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQueryDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Kết quả tìm kiếm",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedSearchResultDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Tìm kiếm theo loại (user, post, event, ...)",
+        "tags": [
+          "Search"
+        ]
+      }
     }
   },
   "info": {
@@ -3183,6 +3280,151 @@
           "totalPages",
           "hasNextPage",
           "hasPrevPage"
+        ]
+      },
+      "SearchResultDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Loại kết quả",
+            "enum": [
+              "user",
+              "post",
+              "event",
+              "group",
+              "hashtags",
+              "location"
+            ]
+          },
+          "results": {
+            "description": "Kết quả",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "total": {
+            "type": "number",
+            "description": "Tổng số kết quả"
+          }
+        },
+        "required": [
+          "type",
+          "results",
+          "total"
+        ]
+      },
+      "PaginatedSearchResultDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "Danh sách kết quả theo loại",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultDto"
+            }
+          },
+          "page": {
+            "type": "number",
+            "description": "Trang hiện tại"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Số lượng trên mỗi trang"
+          },
+          "totalPages": {
+            "type": "number",
+            "description": "Tổng số trang"
+          },
+          "hasNextPage": {
+            "type": "boolean",
+            "description": "Có trang tiếp theo không"
+          },
+          "hasPrevPage": {
+            "type": "boolean",
+            "description": "Có trang trước không"
+          }
+        },
+        "required": [
+          "data",
+          "page",
+          "limit",
+          "totalPages",
+          "hasNextPage",
+          "hasPrevPage"
+        ]
+      },
+      "SearchQueryDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Từ khóa tìm kiếm"
+          },
+          "filter": {
+            "type": "array",
+            "description": "Danh sách filter",
+            "items": {
+              "type": "string",
+              "enum": [
+                "user",
+                "post",
+                "event",
+                "group",
+                "hashtags",
+                "location"
+              ]
+            }
+          },
+          "sportType": {
+            "type": "string",
+            "enum": [
+              "football",
+              "basketball",
+              "tennis",
+              "badminton",
+              "volleyball",
+              "table_tennis",
+              "swimming",
+              "running",
+              "cycling",
+              "yoga",
+              "gym",
+              "martial_arts",
+              "boxing",
+              "golf",
+              "rock_climbing"
+            ],
+            "description": "Môn thể thao"
+          },
+          "level": {
+            "type": "string",
+            "enum": [
+              "beginner",
+              "intermediate",
+              "advanced",
+              "professional"
+            ],
+            "description": "Trình độ"
+          },
+          "page": {
+            "type": "number",
+            "description": "Trang",
+            "default": 1
+          },
+          "limit": {
+            "type": "number",
+            "description": "Số lượng trên mỗi trang",
+            "default": 10
+          },
+          "timeRange": {
+            "type": "string",
+            "description": "Khoảng thời gian (7d, 30d, 90d, all)"
+          }
+        },
+        "required": [
+          "filter"
         ]
       }
     }

--- a/src/i18n/en/search.json
+++ b/src/i18n/en/search.json
@@ -1,0 +1,6 @@
+{
+	"SEARCH_ALL_SUCCESS": "Search all success",
+	"SEARCH_SUCCESS": "Search success",
+	"SEARCH_NO_RESULT": "No result found",
+	"SEARCH_ERROR": "Search error"
+}

--- a/src/i18n/vi/search.json
+++ b/src/i18n/vi/search.json
@@ -1,0 +1,6 @@
+{
+	"SEARCH_ALL_SUCCESS": "Tìm kiếm tất cả thành công",
+	"SEARCH_SUCCESS": "Tìm kiếm thành công",
+	"SEARCH_NO_RESULT": "Không tìm thấy kết quả",
+	"SEARCH_ERROR": "Lỗi tìm kiếm"
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -9,3 +9,4 @@ export * from './friend-request/friend-request.module';
 export * from './achievement/achievement.module';
 export * from './otp/otp.module';
 export * from './file';
+export * from './search/search.module';

--- a/src/modules/search/controllers/search.controller.ts
+++ b/src/modules/search/controllers/search.controller.ts
@@ -1,0 +1,74 @@
+import { Controller, Get, Post, Query, Version, UseGuards, Request, Body } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiBody } from '@nestjs/swagger';
+import { I18n, I18nContext } from 'nestjs-i18n';
+import { Public } from '@common/decorators';
+import { RolesGuard } from '@common/guards';
+import { Roles } from '@common/decorators';
+import { Role } from '@common/enum';
+import { ResponseEntity } from '@common/types';
+import {
+	SearchAllQueryDto,
+	SearchQueryDto,
+	PaginatedSearchResultDto,
+	SearchFilterType,
+} from '../dto/search.dto';
+import { SearchService } from '../providers/search.service';
+
+@ApiTags('Search')
+@Controller('search')
+export class SearchController {
+	constructor(private readonly searchService: SearchService) {}
+
+	@Version('1')
+	@Get('all')
+	@Public()
+	@ApiOperation({ summary: 'Tìm kiếm tất cả các loại (user, post, event, ...)' })
+	@ApiQuery({ name: 'key', required: false, description: 'Từ khóa tìm kiếm' })
+	@ApiQuery({ name: 'page', required: false, type: Number, description: 'Trang', example: 1 })
+	@ApiQuery({
+		name: 'limit',
+		required: false,
+		type: Number,
+		description: 'Số lượng trên mỗi trang',
+		example: 10,
+	})
+	@ApiQuery({
+		name: 'timeRange',
+		required: false,
+		type: String,
+		description: 'Khoảng thời gian (7d, 30d, 90d, all)',
+		example: '7d',
+	})
+	@ApiResponse({ status: 200, description: 'Kết quả tìm kiếm', type: PaginatedSearchResultDto })
+	async searchAll(
+		@Query() query: SearchAllQueryDto,
+		@I18n() i18n: I18nContext,
+		@Request() req,
+	): Promise<ResponseEntity<PaginatedSearchResultDto>> {
+		const result = await this.searchService.searchAll(query, req.user?.id, i18n);
+		return {
+			success: true,
+			data: result,
+			message: i18n.t('search.SEARCH_ALL_SUCCESS'),
+		};
+	}
+
+	@Version('1')
+	@Post()
+	@Public()
+	@ApiOperation({ summary: 'Tìm kiếm theo loại (user, post, event, ...)' })
+	@ApiBody({ type: SearchQueryDto, description: 'Body chứa các tham số tìm kiếm' })
+	@ApiResponse({ status: 200, description: 'Kết quả tìm kiếm', type: PaginatedSearchResultDto })
+	async search(
+		@Body() body: SearchQueryDto,
+		@I18n() i18n: I18nContext,
+		@Request() req,
+	): Promise<ResponseEntity<PaginatedSearchResultDto>> {
+		const result = await this.searchService.search(body, req.user?.id, i18n);
+		return {
+			success: true,
+			data: result,
+			message: i18n.t('search.SEARCH_SUCCESS'),
+		};
+	}
+}

--- a/src/modules/search/dto/search.dto.ts
+++ b/src/modules/search/dto/search.dto.ts
@@ -1,0 +1,111 @@
+import { ApiProperty, ApiQuery } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, IsNumber, IsArray } from 'class-validator';
+import { Type } from 'class-transformer';
+import { SportType, ActivityLevel } from '@modules/user/enums/user.enum';
+
+export enum SearchFilterType {
+	USER = 'user',
+	POST = 'post',
+	EVENT = 'event',
+	GROUP = 'group',
+	HASHTAGS = 'hashtags',
+	LOCATION = 'location',
+}
+
+export class SearchAllQueryDto {
+	@ApiProperty({ description: 'Từ khóa tìm kiếm', required: false })
+	@IsOptional()
+	@IsString()
+	key?: string;
+
+	@ApiProperty({ description: 'Trang', required: false, default: 1 })
+	@IsOptional()
+	@Type(() => Number)
+	@IsNumber()
+	page?: number = 1;
+
+	@ApiProperty({ description: 'Số lượng trên mỗi trang', required: false, default: 10 })
+	@IsOptional()
+	@Type(() => Number)
+	@IsNumber()
+	limit?: number = 10;
+
+	@ApiProperty({ description: 'Khoảng thời gian (7d, 30d, 90d, all)', required: false })
+	@IsOptional()
+	@IsString()
+	timeRange?: string;
+}
+
+export class SearchQueryDto {
+	@ApiProperty({ description: 'Từ khóa tìm kiếm', required: false })
+	@IsOptional()
+	@IsString()
+	key?: string;
+
+	@ApiProperty({
+		enum: SearchFilterType,
+		description: 'Danh sách filter',
+		required: true,
+		isArray: true,
+	})
+	@IsEnum(SearchFilterType, { each: true })
+	filter: SearchFilterType[];
+
+	@ApiProperty({ enum: SportType, description: 'Môn thể thao', required: false })
+	@IsOptional()
+	@IsEnum(SportType)
+	sportType?: SportType;
+
+	@ApiProperty({ enum: ActivityLevel, description: 'Trình độ', required: false })
+	@IsOptional()
+	@IsEnum(ActivityLevel)
+	level?: ActivityLevel;
+
+	@ApiProperty({ description: 'Trang', required: false, default: 1 })
+	@IsOptional()
+	@Type(() => Number)
+	@IsNumber()
+	page?: number = 1;
+
+	@ApiProperty({ description: 'Số lượng trên mỗi trang', required: false, default: 10 })
+	@IsOptional()
+	@Type(() => Number)
+	@IsNumber()
+	limit?: number = 10;
+
+	@ApiProperty({ description: 'Khoảng thời gian (7d, 30d, 90d, all)', required: false })
+	@IsOptional()
+	@IsString()
+	timeRange?: string;
+}
+
+export class SearchResultDto {
+	@ApiProperty({ description: 'Loại kết quả', enum: SearchFilterType })
+	type: SearchFilterType;
+
+	@ApiProperty({ description: 'Kết quả', type: [Object] })
+	results: any[];
+
+	@ApiProperty({ description: 'Tổng số kết quả' })
+	total: number;
+}
+
+export class PaginatedSearchResultDto {
+	@ApiProperty({ type: [SearchResultDto], description: 'Danh sách kết quả theo loại' })
+	data: SearchResultDto[];
+
+	@ApiProperty({ description: 'Trang hiện tại' })
+	page: number;
+
+	@ApiProperty({ description: 'Số lượng trên mỗi trang' })
+	limit: number;
+
+	@ApiProperty({ description: 'Tổng số trang' })
+	totalPages: number;
+
+	@ApiProperty({ description: 'Có trang tiếp theo không' })
+	hasNextPage: boolean;
+
+	@ApiProperty({ description: 'Có trang trước không' })
+	hasPrevPage: boolean;
+}

--- a/src/modules/search/providers/search.service.ts
+++ b/src/modules/search/providers/search.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, Inject, forwardRef } from '@nestjs/common';
+import { I18nContext } from 'nestjs-i18n';
+import {
+	SearchAllQueryDto,
+	SearchQueryDto,
+	PaginatedSearchResultDto,
+	SearchFilterType,
+	SearchResultDto,
+} from '../dto/search.dto';
+import { ISearchRepository } from '../repositories/search.repository';
+import { PostService } from '@modules/post/providers/post.service';
+
+@Injectable()
+export class SearchService {
+	constructor(
+		@Inject(ISearchRepository)
+		private readonly searchRepository: ISearchRepository,
+		@Inject(forwardRef(() => PostService))
+		private readonly postService: PostService,
+	) {}
+
+	async searchAll(
+		query: SearchAllQueryDto,
+		userId: string | undefined,
+		i18n: I18nContext,
+	): Promise<PaginatedSearchResultDto> {
+		const { key, page = 1, limit = 10, timeRange } = query;
+		// Parallel search for all types
+		const [userRes, postRes, eventRes, groupRes, hashtagRes, locationRes] = await Promise.all([
+			this.searchRepository.searchUsers(key, undefined, undefined, page, limit),
+			this.searchRepository.searchPosts(key, undefined, page, limit, timeRange),
+			this.searchRepository.searchEvents(key, undefined, page, limit, timeRange),
+			this.searchRepository.searchGroups(key, page, limit),
+			this.searchRepository.searchHashtags(key, page, limit, timeRange),
+			this.searchRepository.searchLocations(key, page, limit),
+			// Add more as needed
+		]);
+		const data: SearchResultDto[] = [
+			{ type: SearchFilterType.USER, results: userRes.users, total: userRes.total },
+			{ type: SearchFilterType.POST, results: postRes.posts, total: postRes.total },
+			{ type: SearchFilterType.EVENT, results: eventRes.events, total: eventRes.total },
+			{ type: SearchFilterType.GROUP, results: groupRes.groups, total: groupRes.total },
+			{ type: SearchFilterType.HASHTAGS, results: hashtagRes.hashtags, total: hashtagRes.total },
+			{ type: SearchFilterType.LOCATION, results: locationRes.locations, total: locationRes.total },
+		];
+		// Calculate pagination (use max total for totalPages)
+		const maxTotal = Math.max(
+			userRes.total,
+			postRes.total,
+			eventRes.total,
+			groupRes.total,
+			hashtagRes.total,
+			locationRes.total,
+		);
+		const totalPages = Math.ceil(maxTotal / limit);
+		return {
+			data,
+			page,
+			limit,
+			totalPages,
+			hasNextPage: page < totalPages,
+			hasPrevPage: page > 1,
+		};
+	}
+
+	async search(
+		query: SearchQueryDto,
+		userId: string | undefined,
+		i18n: I18nContext,
+	): Promise<PaginatedSearchResultDto> {
+		const { key, filter, sportType, level, page = 1, limit = 10, timeRange } = query;
+		const data: SearchResultDto[] = [];
+		let maxTotal = 0;
+		for (const f of filter) {
+			switch (f) {
+				case SearchFilterType.USER: {
+					const res = await this.searchRepository.searchUsers(key, sportType, level, page, limit);
+					data.push({ type: SearchFilterType.USER, results: res.users, total: res.total });
+					if (res.total > maxTotal) maxTotal = res.total;
+					break;
+				}
+				case SearchFilterType.POST: {
+					const res = await this.searchRepository.searchPosts(
+						key,
+						sportType,
+						page,
+						limit,
+						timeRange,
+					);
+					data.push({ type: SearchFilterType.POST, results: res.posts, total: res.total });
+					if (res.total > maxTotal) maxTotal = res.total;
+					break;
+				}
+				case SearchFilterType.EVENT: {
+					const res = await this.searchRepository.searchEvents(
+						key,
+						sportType,
+						page,
+						limit,
+						timeRange,
+					);
+					data.push({ type: SearchFilterType.EVENT, results: res.events, total: res.total });
+					if (res.total > maxTotal) maxTotal = res.total;
+					break;
+				}
+				case SearchFilterType.GROUP: {
+					const res = await this.searchRepository.searchGroups(key, page, limit);
+					data.push({ type: SearchFilterType.GROUP, results: res.groups, total: res.total });
+					if (res.total > maxTotal) maxTotal = res.total;
+					break;
+				}
+				case SearchFilterType.HASHTAGS: {
+					const res = await this.postService.getPostsByHashtag(
+						key || '',
+						i18n,
+						page,
+						limit,
+						userId,
+					);
+					data.push({ type: SearchFilterType.HASHTAGS, results: res.posts, total: res.total });
+					if (res.total > maxTotal) maxTotal = res.total;
+					break;
+				}
+				case SearchFilterType.LOCATION: {
+					const res = await this.searchRepository.searchLocations(key, page, limit);
+					data.push({ type: SearchFilterType.LOCATION, results: res.locations, total: res.total });
+					if (res.total > maxTotal) maxTotal = res.total;
+					break;
+				}
+				default:
+					break;
+			}
+		}
+		const totalPages = Math.ceil(maxTotal / limit);
+		return {
+			data,
+			page,
+			limit,
+			totalPages,
+			hasNextPage: page < totalPages,
+			hasPrevPage: page > 1,
+		};
+	}
+}

--- a/src/modules/search/repositories/search.repository.impl.ts
+++ b/src/modules/search/repositories/search.repository.impl.ts
@@ -26,14 +26,7 @@ export class SearchRepositoryImpl implements ISearchRepository {
 		const filter: any = {};
 		if (key) {
 			const regex = new RegExp(key, 'i');
-			const orConditions: any[] = [
-				{ fullName: regex },
-				{ firstName: regex },
-				{ lastName: regex },
-				{ 'location.city': regex },
-				{ 'location.district': regex },
-				{ 'location.address': regex },
-			];
+			const orConditions: any[] = [{ fullName: regex }, { firstName: regex }, { lastName: regex }];
 
 			// Check if key is a valid email
 			const emailPattern = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
@@ -134,7 +127,20 @@ export class SearchRepositoryImpl implements ISearchRepository {
 		page: number = 1,
 		limit: number = 10,
 	): Promise<{ locations: any[]; total: number }> {
-		// TODO: Implement location search logic
-		return { locations: [], total: 0 };
+		const skip = (page - 1) * limit;
+		const filter: any = {};
+		if (key) {
+			const regex = new RegExp(key, 'i');
+			filter.$or = [
+				{ 'location.city': regex },
+				{ 'location.district': regex },
+				{ 'location.address': regex },
+			];
+		}
+		const [locations, total] = await Promise.all([
+			this.userModel.find(filter).skip(skip).limit(limit).lean({ virtuals: true }),
+			this.userModel.countDocuments(filter),
+		]);
+		return { locations, total };
 	}
 }

--- a/src/modules/search/repositories/search.repository.impl.ts
+++ b/src/modules/search/repositories/search.repository.impl.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { User } from '@modules/user/entities/user.schema';
+import { Post } from '@modules/post/entities/post.schema';
+import { Event } from '@modules/event/entities/event.schema';
+import { SportType, ActivityLevel } from '@modules/user/enums/user.enum';
+import { ISearchRepository } from './search.repository';
+import { PostStatus } from '@modules/post/entities/post.enum';
+@Injectable()
+export class SearchRepositoryImpl implements ISearchRepository {
+	constructor(
+		@InjectModel(User.name) private readonly userModel: Model<User>,
+		@InjectModel(Post.name) private readonly postModel: Model<Post>,
+		@InjectModel(Event.name) private readonly eventModel: Model<Event>,
+	) {}
+
+	async searchUsers(
+		key?: string,
+		sportType?: SportType,
+		level?: ActivityLevel,
+		page: number = 1,
+		limit: number = 10,
+	): Promise<{ users: any[]; total: number }> {
+		const skip = (page - 1) * limit;
+		const filter: any = {};
+		if (key) {
+			const regex = new RegExp(key, 'i');
+			const orConditions: any[] = [
+				{ fullName: regex },
+				{ firstName: regex },
+				{ lastName: regex },
+				{ 'location.city': regex },
+				{ 'location.district': regex },
+				{ 'location.address': regex },
+			];
+
+			// Check if key is a valid email
+			const emailPattern = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+			const phonePattern = /^\d{8,}$/;
+			if (emailPattern.test(key)) {
+				filter.email = key; // exact match
+			} else if (phonePattern.test(key)) {
+				filter.phone = key; // exact match
+			} else {
+				filter.$or = orConditions;
+			}
+		}
+		if (sportType) {
+			filter.favoritesSports = sportType;
+		}
+		if (level && sportType) {
+			// convert sportType to capitalizedSportType
+			const capitalizedSportType =
+				sportType.charAt(0).toUpperCase() + sportType.slice(1).toLowerCase();
+			filter[`skillLevels.${capitalizedSportType}`] = level;
+		}
+		const [users, total] = await Promise.all([
+			this.userModel.find(filter).skip(skip).limit(limit).lean({ virtuals: true }),
+			this.userModel.countDocuments(filter),
+		]);
+		return { users, total };
+	}
+
+	async searchPosts(
+		key?: string,
+		sportType?: SportType,
+		page: number = 1,
+		limit: number = 10,
+		timeRange?: string,
+	): Promise<{ posts: any[]; total: number }> {
+		const skip = (page - 1) * limit;
+		const filter: any = { approvalStatus: PostStatus.APPROVED };
+		if (key) {
+			const regex = new RegExp(key, 'i');
+			filter.$or = [{ content: regex }, { hashtags: regex }, { type: regex }, { sport: regex }];
+		}
+		if (sportType) {
+			filter.sport = sportType;
+		}
+		// Time range filter
+		if (timeRange && timeRange !== 'all') {
+			const now = new Date();
+			let daysAgo = 7;
+			if (timeRange === '30d') daysAgo = 30;
+			else if (timeRange === '90d') daysAgo = 90;
+			const startDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
+			filter.createdAt = { $gte: startDate };
+		}
+		const [posts, total] = await Promise.all([
+			this.postModel
+				.find(filter)
+				.sort({ likeCount: -1, commentCount: -1, shareCount: -1, createdAt: -1 })
+				.skip(skip)
+				.limit(limit)
+				.lean({ virtuals: true }),
+			this.postModel.countDocuments(filter),
+		]);
+		return { posts, total };
+	}
+
+	async searchEvents(
+		key?: string,
+		sportType?: SportType,
+		page: number = 1,
+		limit: number = 10,
+		timeRange?: string,
+	): Promise<{ events: any[]; total: number }> {
+		// TODO: Implement event search logic
+		return { events: [], total: 0 };
+	}
+
+	async searchGroups(
+		key?: string,
+		page: number = 1,
+		limit: number = 10,
+	): Promise<{ groups: any[]; total: number }> {
+		// TODO: Implement group search logic
+		return { groups: [], total: 0 };
+	}
+
+	async searchHashtags(
+		key?: string,
+		page: number = 1,
+		limit: number = 10,
+		timeRange?: string,
+	): Promise<{ hashtags: any[]; total: number }> {
+		// TODO: Implement hashtag search logic (aggregate hashtags from posts)
+		return { hashtags: [], total: 0 };
+	}
+
+	async searchLocations(
+		key?: string,
+		page: number = 1,
+		limit: number = 10,
+	): Promise<{ locations: any[]; total: number }> {
+		// TODO: Implement location search logic
+		return { locations: [], total: 0 };
+	}
+}

--- a/src/modules/search/repositories/search.repository.ts
+++ b/src/modules/search/repositories/search.repository.ts
@@ -1,0 +1,48 @@
+import { SportType, ActivityLevel } from '@modules/user/enums/user.enum';
+
+export interface ISearchRepository {
+	searchUsers(
+		key?: string,
+		sportType?: SportType,
+		level?: ActivityLevel,
+		page?: number,
+		limit?: number,
+	): Promise<{ users: any[]; total: number }>;
+
+	searchPosts(
+		key?: string,
+		sportType?: SportType,
+		page?: number,
+		limit?: number,
+		timeRange?: string,
+	): Promise<{ posts: any[]; total: number }>;
+
+	searchEvents(
+		key?: string,
+		sportType?: SportType,
+		page?: number,
+		limit?: number,
+		timeRange?: string,
+	): Promise<{ events: any[]; total: number }>;
+
+	searchGroups(
+		key?: string,
+		page?: number,
+		limit?: number,
+	): Promise<{ groups: any[]; total: number }>;
+
+	searchHashtags(
+		key?: string,
+		page?: number,
+		limit?: number,
+		timeRange?: string,
+	): Promise<{ hashtags: any[]; total: number }>;
+
+	searchLocations(
+		key?: string,
+		page?: number,
+		limit?: number,
+	): Promise<{ locations: any[]; total: number }>;
+}
+
+export const ISearchRepository = Symbol('ISearchRepository');

--- a/src/modules/search/search.module.ts
+++ b/src/modules/search/search.module.ts
@@ -1,0 +1,29 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { SearchController } from './controllers/search.controller';
+import { SearchService } from './providers/search.service';
+import { UserModule } from '../user/user.module';
+import { PostModule } from '../post/post.module';
+import { EventModule } from '../event/event.module';
+import { ISearchRepository } from './repositories/search.repository';
+import { SearchRepositoryImpl } from './repositories/search.repository.impl';
+import { User, UserSchema } from '../user/entities/user.schema';
+import { Post, PostSchema } from '../post/entities/post.schema';
+import { Event, EventSchema } from '../event/entities/event.schema';
+
+@Module({
+	imports: [
+		MongooseModule.forFeature([
+			{ name: User.name, schema: UserSchema },
+			{ name: Post.name, schema: PostSchema },
+			{ name: Event.name, schema: EventSchema },
+		]),
+		forwardRef(() => UserModule),
+		forwardRef(() => PostModule),
+		forwardRef(() => EventModule),
+	],
+	controllers: [SearchController],
+	providers: [SearchService, { provide: ISearchRepository, useClass: SearchRepositoryImpl }],
+	exports: [SearchService],
+})
+export class SearchModule {}

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -11,6 +11,7 @@ import {
 	AchievementModule,
 	OtpModule,
 	FileModule,
+	SearchModule,
 } from '@modules';
 import { EmailModule } from '@modules/email/email.module';
 @Module({
@@ -27,6 +28,7 @@ import { EmailModule } from '@modules/email/email.module';
 		AchievementModule,
 		OtpModule,
 		FileModule,
+		SearchModule,
 	],
 	exports: [
 		AuthModule,
@@ -41,6 +43,7 @@ import { EmailModule } from '@modules/email/email.module';
 		AchievementModule,
 		OtpModule,
 		FileModule,
+		SearchModule,
 	],
 })
 export class SharedModule {}


### PR DESCRIPTION
Backend Tasks Completed:
1. GET /search/all: search ra tất cả kết quả, có thể là post, user, event, ... ✅
2. GET /search?key={}&&filter={}&&sportType={}&&level={} ✅

- với key là giá trị người dùng nhập vào thanh search, filter = user, event, post, group, hashtags, location
- kết quả là các giá trị của filter
- param: filter là bắt buộc, key, sportType và level là optional
- sportType và level tương ứng với SportType và ActivityLevel trong @user.schema.ts

NOTE: 
- vì level chính là trình độ của user, nên giá trị level được truyền sẽ ra kết quả là danh sách user tương ứng với sportType và level đó
- nếu filter là hashtag, sẽ search ra các bài post có hashtag đó
- thuật toán sử dụng giống với getTrendingHashtag và getTrendingPost