### PR TITLE
Epic 3.3: Notification APIs & Triggers 

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -815,6 +815,190 @@
         ]
       }
     },
+    "/api/v1/notifications": {
+      "get": {
+        "operationId": "NotificationController_getNotifications_v1",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "example": 10,
+              "type": "number"
+            }
+          },
+          {
+            "name": "isRead",
+            "required": false,
+            "in": "query",
+            "description": "Lọc theo đã đọc/chưa đọc (nếu không truyền thì lấy tất cả)",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lấy danh sách thông báo thành công"
+          }
+        },
+        "summary": "Lấy danh sách thông báo của người dùng hiện tại",
+        "tags": [
+          "Notification"
+        ]
+      }
+    },
+    "/api/v1/notifications/unread-count": {
+      "get": {
+        "operationId": "NotificationController_getUnreadCount_v1",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Trang thông báo chưa đọc muốn lấy (không bắt buộc)",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Số lượng thông báo chưa đọc muốn lấy (không bắt buộc)",
+            "schema": {
+              "example": 10,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lấy số lượng và danh sách thông báo chưa đọc thành công"
+          }
+        },
+        "summary": "Lấy số lượng và danh sách thông báo chưa đọc",
+        "tags": [
+          "Notification"
+        ]
+      }
+    },
+    "/api/v1/notifications/{notificationId}/read": {
+      "put": {
+        "operationId": "NotificationController_markAsRead_v1",
+        "parameters": [
+          {
+            "name": "notificationId",
+            "required": true,
+            "in": "path",
+            "description": "ID của thông báo",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Đánh dấu thông báo đã đọc thành công"
+          }
+        },
+        "summary": "Đánh dấu thông báo đã đọc",
+        "tags": [
+          "Notification"
+        ]
+      }
+    },
+    "/api/v1/notifications/read-all": {
+      "put": {
+        "operationId": "NotificationController_markAllAsRead_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Đánh dấu tất cả thông báo đã đọc thành công"
+          }
+        },
+        "summary": "Đánh dấu tất cả thông báo đã đọc",
+        "tags": [
+          "Notification"
+        ]
+      }
+    },
+    "/api/v1/notifications/{notificationId}/unread": {
+      "put": {
+        "operationId": "NotificationController_markAsUnread_v1",
+        "parameters": [
+          {
+            "name": "notificationId",
+            "required": true,
+            "in": "path",
+            "description": "ID của thông báo",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Đánh dấu thông báo là chưa đọc thành công"
+          }
+        },
+        "summary": "Đánh dấu thông báo là chưa đọc",
+        "tags": [
+          "Notification"
+        ]
+      }
+    },
+    "/api/v1/notifications/clear-all": {
+      "delete": {
+        "operationId": "NotificationController_clearAll_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Xóa tất cả thông báo thành công"
+          }
+        },
+        "summary": "Xóa (ẩn) tất cả thông báo của user",
+        "tags": [
+          "Notification"
+        ]
+      }
+    },
+    "/api/v1/notifications/{notificationId}": {
+      "delete": {
+        "operationId": "NotificationController_deleteNotification_v1",
+        "parameters": [
+          {
+            "name": "notificationId",
+            "required": true,
+            "in": "path",
+            "description": "ID của thông báo",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Xóa thông báo thành công"
+          }
+        },
+        "summary": "Xóa (ẩn) một thông báo cụ thể",
+        "tags": [
+          "Notification"
+        ]
+      }
+    },
     "/api/v1/posts": {
       "post": {
         "operationId": "PostController_createPost_v1",

--- a/src/i18n/en/notification.json
+++ b/src/i18n/en/notification.json
@@ -1,0 +1,10 @@
+{
+	"LIST_RETRIEVED_SUCCESS": "Notification list retrieved successfully",
+	"UNREAD_COUNT_SUCCESS": "Unread notification count retrieved successfully",
+	"MARK_READ_SUCCESS": "Notification marked as read successfully",
+	"MARK_ALL_READ_SUCCESS": "All notifications marked as read successfully",
+	"MARK_UNREAD_SUCCESS": "Notification marked as unread successfully",
+	"DELETE_SUCCESS": "Notification deleted successfully",
+	"CLEAR_ALL_SUCCESS": "All notifications deleted successfully",
+	"NOT_FOUND": "Notification not found"
+}

--- a/src/i18n/vi/notification.json
+++ b/src/i18n/vi/notification.json
@@ -1,0 +1,10 @@
+{
+	"LIST_RETRIEVED_SUCCESS": "Lấy danh sách thông báo thành công",
+	"UNREAD_COUNT_SUCCESS": "Lấy số lượng thông báo chưa đọc thành công",
+	"MARK_READ_SUCCESS": "Đánh dấu thông báo đã đọc thành công",
+	"MARK_ALL_READ_SUCCESS": "Đánh dấu tất cả thông báo đã đọc thành công",
+	"MARK_UNREAD_SUCCESS": "Đánh dấu thông báo chưa đọc thành công",
+	"DELETE_SUCCESS": "Xóa thông báo thành công",
+	"CLEAR_ALL_SUCCESS": "Xóa tất cả thông báo thành công",
+	"NOT_FOUND": "Không tìm thấy thông báo"
+}

--- a/src/modules/notification/controllers/notification.controller.ts
+++ b/src/modules/notification/controllers/notification.controller.ts
@@ -1,4 +1,203 @@
-import { Controller } from '@nestjs/common';
+import {
+	Controller,
+	Get,
+	Put,
+	Delete,
+	Param,
+	Query,
+	Request,
+	UseGuards,
+	Version,
+	BadRequestException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { NotificationService } from '../providers/notification.service';
+import { RolesGuard } from '@common/guards';
+import { Roles } from '@common/decorators';
+import { Role } from '@common/enum';
+import { I18n, I18nContext } from 'nestjs-i18n';
+import { ResponseEntity } from '@common/types';
 
-@Controller('notification')
-export class NotificationController {}
+@ApiTags('Notification')
+@Controller('notifications')
+export class NotificationController {
+	constructor(private readonly notificationService: NotificationService) {}
+
+	@Version('1')
+	@Get()
+	@UseGuards(RolesGuard)
+	@Roles(Role.USER, Role.ADMIN)
+	@ApiOperation({ summary: 'Lấy danh sách thông báo của người dùng hiện tại' })
+	@ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+	@ApiQuery({ name: 'limit', required: false, type: Number, example: 10 })
+	@ApiQuery({
+		name: 'isRead',
+		required: false,
+		type: Boolean,
+		description: 'Lọc theo đã đọc/chưa đọc (nếu không truyền thì lấy tất cả)',
+	})
+	@ApiResponse({ status: 200, description: 'Lấy danh sách thông báo thành công' })
+	async getNotifications(
+		@Request() req,
+		@I18n() i18n: I18nContext,
+		@Query('page') page: number = 1,
+		@Query('limit') limit: number = 10,
+		@Query('isRead') isRead?: string,
+	): Promise<ResponseEntity<any>> {
+		const userId = req.user.id;
+		const isReadBool = isRead === undefined ? undefined : isRead === 'true';
+		const { notifications, total } = await this.notificationService.getNotifications(
+			userId,
+			page,
+			limit,
+			isReadBool,
+		);
+		const totalPages = Math.ceil(total / limit);
+		return {
+			success: true,
+			data: { notifications, total, page, limit, totalPages },
+			message: i18n.t('notification.LIST_RETRIEVED_SUCCESS'),
+		};
+	}
+
+	@Version('1')
+	@Get('unread-count')
+	@UseGuards(RolesGuard)
+	@Roles(Role.USER, Role.ADMIN)
+	@ApiOperation({ summary: 'Lấy số lượng và danh sách thông báo chưa đọc' })
+	@ApiQuery({
+		name: 'page',
+		required: false,
+		type: Number,
+		example: 1,
+		description: 'Trang thông báo chưa đọc muốn lấy (không bắt buộc)',
+	})
+	@ApiQuery({
+		name: 'limit',
+		required: false,
+		type: Number,
+		example: 10,
+		description: 'Số lượng thông báo chưa đọc muốn lấy (không bắt buộc)',
+	})
+	@ApiResponse({
+		status: 200,
+		description: 'Lấy số lượng và danh sách thông báo chưa đọc thành công',
+	})
+	async getUnreadCount(
+		@Request() req,
+		@I18n() i18n: I18nContext,
+		@Query('page') page?: number,
+		@Query('limit') limit?: number,
+	): Promise<ResponseEntity<{ count: number; notifications: any[] }>> {
+		const { count, notifications } = await this.notificationService.getUnreadNotificationsWithCount(
+			req.user.id,
+			page,
+			limit,
+		);
+		return {
+			success: true,
+			data: { count, notifications },
+			message: i18n.t('notification.UNREAD_COUNT_SUCCESS'),
+		};
+	}
+
+	@Version('1')
+	@Put(':notificationId/read')
+	@UseGuards(RolesGuard)
+	@Roles(Role.USER, Role.ADMIN)
+	@ApiOperation({ summary: 'Đánh dấu thông báo đã đọc' })
+	@ApiParam({ name: 'notificationId', description: 'ID của thông báo' })
+	@ApiResponse({ status: 200, description: 'Đánh dấu thông báo đã đọc thành công' })
+	async markAsRead(
+		@Param('notificationId') notificationId: string,
+		@I18n() i18n: I18nContext,
+	): Promise<ResponseEntity<null>> {
+		try {
+			await this.notificationService.markAsRead(notificationId, i18n);
+			return {
+				success: true,
+				message: i18n.t('notification.MARK_READ_SUCCESS'),
+			};
+		} catch (e) {
+			throw new BadRequestException(e.message);
+		}
+	}
+
+	@Version('1')
+	@Put('read-all')
+	@UseGuards(RolesGuard)
+	@Roles(Role.USER, Role.ADMIN)
+	@ApiOperation({ summary: 'Đánh dấu tất cả thông báo đã đọc' })
+	@ApiResponse({ status: 200, description: 'Đánh dấu tất cả thông báo đã đọc thành công' })
+	async markAllAsRead(@Request() req, @I18n() i18n: I18nContext): Promise<ResponseEntity<null>> {
+		const userId = req.user.id;
+		await this.notificationService.markAllAsRead(userId);
+		return {
+			success: true,
+			message: i18n.t('notification.MARK_ALL_READ_SUCCESS'),
+		};
+	}
+
+	@Version('1')
+	@Put(':notificationId/unread')
+	@UseGuards(RolesGuard)
+	@Roles(Role.USER, Role.ADMIN)
+	@ApiOperation({ summary: 'Đánh dấu thông báo là chưa đọc' })
+	@ApiParam({ name: 'notificationId', description: 'ID của thông báo' })
+	@ApiResponse({ status: 200, description: 'Đánh dấu thông báo là chưa đọc thành công' })
+	async markAsUnread(
+		@Param('notificationId') notificationId: string,
+		@I18n() i18n: I18nContext,
+	): Promise<ResponseEntity<null>> {
+		try {
+			await this.notificationService.markAsUnread(notificationId, i18n);
+			return {
+				success: true,
+				message: i18n.t('notification.MARK_UNREAD_SUCCESS'),
+			};
+		} catch (e) {
+			throw new BadRequestException(e.message);
+		}
+	}
+
+	@Version('1')
+	@Delete('clear-all')
+	@UseGuards(RolesGuard)
+	@Roles(Role.USER, Role.ADMIN)
+	@ApiOperation({ summary: 'Xóa (ẩn) tất cả thông báo của user' })
+	@ApiResponse({ status: 200, description: 'Xóa tất cả thông báo thành công' })
+	async clearAll(@Request() req, @I18n() i18n: I18nContext): Promise<ResponseEntity<null>> {
+		try {
+			const userId = req.user.id;
+			await this.notificationService.clearAll(userId);
+			return {
+				success: true,
+				message: i18n.t('notification.CLEAR_ALL_SUCCESS'),
+			};
+		} catch (e) {
+			throw new BadRequestException(e.message);
+		}
+	}
+
+	@Version('1')
+	@Delete(':notificationId')
+	@UseGuards(RolesGuard)
+	@Roles(Role.USER, Role.ADMIN)
+	@ApiOperation({ summary: 'Xóa (ẩn) một thông báo cụ thể' })
+	@ApiParam({ name: 'notificationId', description: 'ID của thông báo' })
+	@ApiResponse({ status: 200, description: 'Xóa thông báo thành công' })
+	async deleteNotification(
+		@Param('notificationId') notificationId: string,
+		@I18n() i18n: I18nContext,
+	): Promise<ResponseEntity<null>> {
+		try {
+			await this.notificationService.deleteNotification(notificationId, i18n);
+			return {
+				success: true,
+				message: i18n.t('notification.DELETE_SUCCESS'),
+			};
+		} catch (e) {
+			throw new BadRequestException(e.message);
+		}
+	}
+}

--- a/src/modules/notification/providers/notification.service.ts
+++ b/src/modules/notification/providers/notification.service.ts
@@ -3,10 +3,15 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Notification } from '../entities/notification.schema';
 import { NotificationType, ReferenceModel } from '../entities/notification.enum';
+import { INotificationRepository } from '../repositories/notification.repository';
+import { I18nContext } from 'nestjs-i18n';
 
 @Injectable()
 export class NotificationService {
-	constructor(@InjectModel(Notification.name) private notificationModel: Model<Notification>) {}
+	constructor(
+		@InjectModel(Notification.name) private notificationModel: Model<Notification>,
+		private readonly notificationRepository: INotificationRepository,
+	) {}
 
 	async createNotification(data: {
 		recipient: string;
@@ -19,5 +24,49 @@ export class NotificationService {
 	}) {
 		const notification = new this.notificationModel(data);
 		return await notification.save();
+	}
+
+	async getNotifications(userId: string, page: number, limit: number, isRead: boolean | undefined) {
+		return this.notificationRepository.findNotificationsByUser(userId, page, limit, isRead);
+	}
+
+	async getUnreadCount(userId: string) {
+		return this.notificationRepository.countUnreadNotifications(userId);
+	}
+
+	async getUnreadNotificationsWithCount(userId: string, page?: number, limit?: number) {
+		const [count, notifications] = await Promise.all([
+			this.notificationRepository.countUnreadNotifications(userId),
+			this.notificationRepository.getUnreadNotifications(userId, page, limit),
+		]);
+		return { count, notifications };
+	}
+
+	async markAsRead(notificationId: string, i18n: I18nContext) {
+		const result = await this.notificationRepository.markAsRead(notificationId);
+		if (result.modifiedCount === 0) throw new Error(i18n.t('notification.NOT_FOUND'));
+		return true;
+	}
+
+	async markAllAsRead(userId: string) {
+		await this.notificationRepository.markAllAsRead(userId);
+		return true;
+	}
+
+	async markAsUnread(notificationId: string, i18n: I18nContext) {
+		const result = await this.notificationRepository.markAsUnread(notificationId);
+		if (result.modifiedCount === 0) throw new Error(i18n.t('notification.NOT_FOUND'));
+		return true;
+	}
+
+	async deleteNotification(notificationId: string, i18n: I18nContext) {
+		const result = await this.notificationRepository.softDelete(notificationId);
+		if (result.modifiedCount === 0) throw new Error(i18n.t('notification.NOT_FOUND'));
+		return true;
+	}
+
+	async clearAll(userId: string) {
+		await this.notificationRepository.clearAll(userId);
+		return true;
 	}
 }

--- a/src/modules/notification/repositories/notification.repository.impl.ts
+++ b/src/modules/notification/repositories/notification.repository.impl.ts
@@ -1,5 +1,90 @@
 import { Injectable } from '@nestjs/common';
 import { INotificationRepository } from './notification.repository';
+import { Model, Types } from 'mongoose';
+import { InjectModel } from '@nestjs/mongoose';
+import { Notification } from '../entities/notification.schema';
 
 @Injectable()
-export class NotificationRepositoryImpl implements INotificationRepository {}
+export class NotificationRepositoryImpl implements INotificationRepository {
+	constructor(
+		@InjectModel(Notification.name)
+		private readonly notificationModel: Model<Notification>,
+	) {}
+
+	async findNotificationsByUser(
+		userId: string,
+		page: number = 1,
+		limit: number = 10,
+		isRead?: boolean,
+	) {
+		const filter: any = { recipient: userId, isActive: true };
+		if (typeof isRead === 'boolean' && isRead !== undefined) filter.isRead = isRead;
+		const [notifications, total] = await Promise.all([
+			this.notificationModel
+				.find(filter)
+				.sort({ createdAt: -1 })
+				.skip((page - 1) * limit)
+				.limit(limit)
+				.lean(),
+			this.notificationModel.countDocuments(filter),
+		]);
+		return { notifications, total };
+	}
+
+	async countUnreadNotifications(userId: string) {
+		return this.notificationModel.countDocuments({
+			recipient: userId,
+			isRead: false,
+			isActive: true,
+		});
+	}
+
+	async getUnreadNotifications(userId: string, page?: number, limit?: number) {
+		const query = this.notificationModel
+			.find({
+				recipient: userId,
+				isRead: false,
+				isActive: true,
+			})
+			.sort({ createdAt: -1 });
+
+		if (page && limit) {
+			query.skip((page - 1) * limit);
+		}
+
+		if (limit) {
+			query.limit(limit);
+		}
+
+		return query.lean();
+	}
+
+	async markAsRead(notificationId: string) {
+		return this.notificationModel.updateOne(
+			{ _id: new Types.ObjectId(notificationId) },
+			{ $set: { isRead: true } },
+		);
+	}
+
+	async markAllAsRead(userId: string) {
+		return this.notificationModel.updateMany(
+			{ recipient: userId, isActive: true, isRead: false },
+			{ $set: { isRead: true } },
+		);
+	}
+
+	async markAsUnread(notificationId: string) {
+		return this.notificationModel.updateOne(
+			{ _id: new Types.ObjectId(notificationId) },
+			{ $set: { isRead: false } },
+		);
+	}
+
+	async softDelete(notificationId: string) {
+		return this.notificationModel.deleteOne({ _id: new Types.ObjectId(notificationId) });
+	}
+
+	async clearAll(userId: string) {
+		return this.notificationModel.deleteMany({ recipient: userId, isActive: true });
+	}
+}

--- a/src/modules/notification/repositories/notification.repository.ts
+++ b/src/modules/notification/repositories/notification.repository.ts
@@ -1,3 +1,24 @@
-export interface INotificationRepository {}
+export interface INotificationRepository {
+	findNotificationsByUser(
+		userId: string,
+		page: number,
+		limit: number,
+		isRead?: boolean,
+	): Promise<{ notifications: any[]; total: number }>;
+
+	countUnreadNotifications(userId: string): Promise<number>;
+
+	getUnreadNotifications(userId: string, page?: number, limit?: number): Promise<any[]>;
+
+	markAsRead(notificationId: string): Promise<any>;
+
+	markAllAsRead(userId: string): Promise<any>;
+
+	markAsUnread(notificationId: string): Promise<any>;
+
+	softDelete(notificationId: string): Promise<any>;
+
+	clearAll(userId: string): Promise<any>;
+}
 
 export const INotificationRepository = Symbol('INotificationRepository');

--- a/src/modules/post/providers/post.service.ts
+++ b/src/modules/post/providers/post.service.ts
@@ -215,6 +215,25 @@ export class PostService {
 			);
 		}
 
+		// Gửi notification cho các user được tag
+		if (createPostDto.taggedUsers && createPostDto.taggedUsers.length > 0) {
+			await Promise.all(
+				createPostDto.taggedUsers
+					.filter(taggedUserId => taggedUserId !== authorId) // Không gửi notification cho chính mình
+					.map(taggedUserId =>
+						this.notificationService.createNotification({
+							recipient: taggedUserId,
+							sender: authorId,
+							type: NotificationType.MENTION,
+							title: 'You have been tagged in a post',
+							message: 'You have been tagged in a post',
+							referenceId: (post as any)._id.toString(),
+							referenceModel: ReferenceModel.POST,
+						}),
+					),
+			);
+		}
+
 		return post as PostResponseDto;
 	}
 
@@ -276,6 +295,36 @@ export class PostService {
 
 		try {
 			const post = await this.postRepository.update(postId, updateData, images, video);
+
+			// Gửi notification cho các user mới được tag (nếu có cập nhật taggedUsers)
+			if (updatePostDto.taggedUsers !== undefined) {
+				// Lấy danh sách taggedUsers cũ để so sánh
+				const postBefore = await this.postRepository.findById(postId);
+				const oldTagged = (postBefore.taggedUsers || []).map(id => id.toString());
+
+				// Tìm những user mới được tag
+				const newTagged = updatePostDto.taggedUsers.filter(
+					id => !oldTagged.includes(id) && id !== userId,
+				);
+
+				// Gửi notification cho các user mới được tag
+				if (newTagged.length > 0) {
+					await Promise.all(
+						newTagged.map(taggedUserId =>
+							this.notificationService.createNotification({
+								recipient: taggedUserId,
+								sender: userId,
+								type: NotificationType.MENTION,
+								title: 'You have been tagged in a post',
+								message: 'You have been tagged in a post',
+								referenceId: postId,
+								referenceModel: ReferenceModel.POST,
+							}),
+						),
+					);
+				}
+			}
+
 			return post as PostResponseDto;
 		} catch (error) {
 			if (error.message === 'Post not found') {


### PR DESCRIPTION
Backend Tasks Completed:
GET /api/v1/notifications - Lấy danh sách thông báo đã được người dùng đọc

GET /api/v1/notifications/unread-count - Lấy số lượng thông báo chưa đọc

PUT /api/v1/notifications/{notificationId}/read - Đánh dấu thông báo đã đọc

PUT /api/v1/notifications/read-all - Đánh dấu tất cả thông báo đã đọc

PUT /api/v1/notifications/{notificationId}/unread - Đánh dấu thông báo là chưa đọc

DELETE /api/v1/notifications/{notificationId} - Xóa một thông báo cụ thể

DELETE /api/v1/notifications/clear-all - Xóa tất cả thông báo của người dùng