### PR TITLE
feat(INTERACTION-BE-003): Implement tagged user for comment APIs

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2249,6 +2249,148 @@
         ]
       }
     },
+    "/api/v1/comments/{commentId}/tagged-users": {
+      "post": {
+        "operationId": "CommentController_tagUsers_v1",
+        "parameters": [
+          {
+            "name": "commentId",
+            "required": true,
+            "in": "path",
+            "description": "ID của comment",
+            "schema": {
+              "example": "507f1f77bcf86cd799439011",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "Tag users vào comment",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Danh sách ID người dùng được tag",
+                    "example": [
+                      "507f1f77bcf86cd799439011",
+                      "507f1f77bcf86cd799439012"
+                    ]
+                  }
+                },
+                "required": [
+                  "userIds"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tag users thành công",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Dữ liệu không hợp lệ"
+          },
+          "401": {
+            "description": "Không có quyền truy cập"
+          },
+          "403": {
+            "description": "Không có quyền chỉnh sửa comment này"
+          },
+          "404": {
+            "description": "Không tìm thấy comment"
+          }
+        },
+        "summary": "Tag users vào comment",
+        "tags": [
+          "Comment"
+        ]
+      },
+      "put": {
+        "operationId": "CommentController_updateTaggedUsers_v1",
+        "parameters": [
+          {
+            "name": "commentId",
+            "required": true,
+            "in": "path",
+            "description": "ID của comment",
+            "schema": {
+              "example": "507f1f77bcf86cd799439011",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "Cập nhật danh sách tagged users",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Danh sách ID người dùng được tag (sẽ thay thế toàn bộ danh sách cũ)",
+                    "example": [
+                      "507f1f77bcf86cd799439011",
+                      "507f1f77bcf86cd799439012"
+                    ]
+                  }
+                },
+                "required": [
+                  "userIds"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cập nhật tagged users thành công",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Dữ liệu không hợp lệ"
+          },
+          "401": {
+            "description": "Không có quyền truy cập"
+          },
+          "403": {
+            "description": "Không có quyền chỉnh sửa comment này"
+          },
+          "404": {
+            "description": "Không tìm thấy comment"
+          }
+        },
+        "summary": "Cập nhật danh sách tagged users (thay thế toàn bộ)",
+        "tags": [
+          "Comment"
+        ]
+      }
+    },
     "/api/v1/search/all": {
       "get": {
         "operationId": "SearchController_searchAll_v1",
@@ -3429,6 +3571,13 @@
               "$ref": "#/components/schemas/ObjectId"
             }
           },
+          "taggedUsers": {
+            "description": "Danh sách ID người dùng được tag",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectId"
+            }
+          },
           "isActive": {
             "type": "boolean",
             "description": "Trạng thái hoạt động"
@@ -3497,6 +3646,7 @@
           "author",
           "content",
           "likes",
+          "taggedUsers",
           "isActive",
           "isHidden",
           "likeCount",

--- a/src/i18n/en/comment.json
+++ b/src/i18n/en/comment.json
@@ -25,5 +25,13 @@
 	"UNLIKE_SUCCESS": "Comment unliked successfully",
 	"UNLIKE_FAILED": "Failed to unlike comment",
 	"ALREADY_LIKED": "You have already liked this comment",
-	"NOT_LIKED": "You have not liked this comment yet"
+	"NOT_LIKED": "You have not liked this comment yet",
+	"TAG_USERS_SUCCESS": "Users tagged successfully",
+	"TAG_USERS_FAILED": "Failed to tag users",
+	"UNTAG_USERS_SUCCESS": "Users untagged successfully",
+	"UNTAG_USERS_FAILED": "Failed to untag users",
+	"UPDATE_TAGGED_USERS_SUCCESS": "Tagged users updated successfully",
+	"UPDATE_TAGGED_USERS_FAILED": "Failed to update tagged users",
+	"TAGGED_USERS_RETRIEVED_SUCCESS": "Tagged users retrieved successfully",
+	"TAGGED_USERS_RETRIEVAL_FAILED": "Failed to retrieve tagged users"
 }

--- a/src/i18n/vi/comment.json
+++ b/src/i18n/vi/comment.json
@@ -25,5 +25,13 @@
 	"UNLIKE_SUCCESS": "Bỏ like comment thành công",
 	"UNLIKE_FAILED": "Bỏ like comment thất bại",
 	"ALREADY_LIKED": "Bạn đã like comment này rồi",
-	"NOT_LIKED": "Bạn chưa like comment này"
+	"NOT_LIKED": "Bạn chưa like comment này",
+	"TAG_USERS_SUCCESS": "Tag người dùng thành công",
+	"TAG_USERS_FAILED": "Tag người dùng thất bại",
+	"UNTAG_USERS_SUCCESS": "Bỏ tag người dùng thành công",
+	"UNTAG_USERS_FAILED": "Bỏ tag người dùng thất bại",
+	"UPDATE_TAGGED_USERS_SUCCESS": "Cập nhật danh sách tagged users thành công",
+	"UPDATE_TAGGED_USERS_FAILED": "Cập nhật danh sách tagged users thất bại",
+	"TAGGED_USERS_RETRIEVED_SUCCESS": "Lấy danh sách tagged users thành công",
+	"TAGGED_USERS_RETRIEVAL_FAILED": "Lấy danh sách tagged users thất bại"
 }

--- a/src/modules/comment/comment.module.ts
+++ b/src/modules/comment/comment.module.ts
@@ -6,6 +6,7 @@ import { CommentController } from './controllers/comment.controller';
 import { CommentService } from './providers/comment.service';
 import { ICommentRepository } from './repositories/comment.repository';
 import { CommentRepositoryImpl } from './repositories/comment.repository.impl';
+import { NotificationModule } from '@modules/notification/notification.module';
 
 @Module({
 	imports: [
@@ -13,6 +14,7 @@ import { CommentRepositoryImpl } from './repositories/comment.repository.impl';
 			{ name: Comment.name, schema: CommentSchema },
 			{ name: Post.name, schema: PostSchema },
 		]),
+		NotificationModule,
 	],
 	controllers: [CommentController],
 	providers: [CommentService, { provide: ICommentRepository, useClass: CommentRepositoryImpl }],

--- a/src/modules/comment/controllers/comment.controller.ts
+++ b/src/modules/comment/controllers/comment.controller.ts
@@ -23,6 +23,7 @@ import {
 	UpdateCommentDto,
 	CreateReplyDto,
 	UpdateCommentVisibilityDto,
+	TagUsersDto,
 } from '../dto/comment.dto';
 import { I18n, I18nContext } from 'nestjs-i18n';
 import { Public } from '@common/decorators';
@@ -524,6 +525,121 @@ export class CommentController {
 				throw error;
 			}
 			throw new BadRequestException(i18n.t('comment.UNLIKE_FAILED'));
+		}
+	}
+
+	@Version('1')
+	@Post(':commentId/tagged-users')
+	@UseGuards(RolesGuard)
+	@Roles(Role.USER, Role.ADMIN)
+	@ApiOperation({ summary: 'Tag users vào comment' })
+	@ApiParam({
+		name: 'commentId',
+		description: 'ID của comment',
+		example: '507f1f77bcf86cd799439011',
+	})
+	@ApiBody({
+		description: 'Tag users vào comment',
+		schema: {
+			type: 'object',
+			properties: {
+				userIds: {
+					type: 'array',
+					items: { type: 'string' },
+					description: 'Danh sách ID người dùng được tag',
+					example: ['507f1f77bcf86cd799439011', '507f1f77bcf86cd799439012'],
+				},
+			},
+			required: ['userIds'],
+		},
+	})
+	@ApiResponse({
+		status: 200,
+		description: 'Tag users thành công',
+		type: CommentResponseDto,
+	})
+	@ApiResponse({ status: 400, description: 'Dữ liệu không hợp lệ' })
+	@ApiResponse({ status: 401, description: 'Không có quyền truy cập' })
+	@ApiResponse({ status: 403, description: 'Không có quyền chỉnh sửa comment này' })
+	@ApiResponse({ status: 404, description: 'Không tìm thấy comment' })
+	async tagUsers(
+		@Request() req,
+		@Param('commentId') commentId: string,
+		@Body() tagUsersDto: TagUsersDto,
+		@I18n() i18n: I18nContext,
+	): Promise<ResponseEntity<CommentResponseDto>> {
+		try {
+			const comment = await this.commentService.tagUsers(commentId, req.user.id, tagUsersDto, i18n);
+			return {
+				success: true,
+				data: comment as any as CommentResponseDto,
+				message: i18n.t('comment.TAG_USERS_SUCCESS'),
+			};
+		} catch (error) {
+			if (error instanceof BadRequestException || error instanceof ForbiddenException) {
+				throw error;
+			}
+			throw new BadRequestException(i18n.t('comment.TAG_USERS_FAILED'));
+		}
+	}
+
+	@Version('1')
+	@Put(':commentId/tagged-users')
+	@UseGuards(RolesGuard)
+	@Roles(Role.USER, Role.ADMIN)
+	@ApiOperation({ summary: 'Cập nhật danh sách tagged users (thay thế toàn bộ)' })
+	@ApiParam({
+		name: 'commentId',
+		description: 'ID của comment',
+		example: '507f1f77bcf86cd799439011',
+	})
+	@ApiBody({
+		description: 'Cập nhật danh sách tagged users',
+		schema: {
+			type: 'object',
+			properties: {
+				userIds: {
+					type: 'array',
+					items: { type: 'string' },
+					description: 'Danh sách ID người dùng được tag (sẽ thay thế toàn bộ danh sách cũ)',
+					example: ['507f1f77bcf86cd799439011', '507f1f77bcf86cd799439012'],
+				},
+			},
+			required: ['userIds'],
+		},
+	})
+	@ApiResponse({
+		status: 200,
+		description: 'Cập nhật tagged users thành công',
+		type: CommentResponseDto,
+	})
+	@ApiResponse({ status: 400, description: 'Dữ liệu không hợp lệ' })
+	@ApiResponse({ status: 401, description: 'Không có quyền truy cập' })
+	@ApiResponse({ status: 403, description: 'Không có quyền chỉnh sửa comment này' })
+	@ApiResponse({ status: 404, description: 'Không tìm thấy comment' })
+	async updateTaggedUsers(
+		@Request() req,
+		@Param('commentId') commentId: string,
+		@Body() tagUsersDto: TagUsersDto,
+		@I18n() i18n: I18nContext,
+	): Promise<ResponseEntity<CommentResponseDto>> {
+		try {
+			const comment = await this.commentService.updateTaggedUsers(
+				commentId,
+				req.user.id,
+				tagUsersDto,
+				i18n,
+			);
+			return {
+				success: true,
+				data: comment as any as CommentResponseDto,
+				message: i18n.t('comment.UPDATE_TAGGED_USERS_SUCCESS'),
+			};
+		} catch (error) {
+			if (error instanceof BadRequestException || error instanceof ForbiddenException) {
+				throw error;
+			}
+			throw new BadRequestException(i18n.t('comment.UPDATE_TAGGED_USERS_FAILED'));
 		}
 	}
 }

--- a/src/modules/comment/dto/comment.dto.ts
+++ b/src/modules/comment/dto/comment.dto.ts
@@ -1,6 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Types } from 'mongoose';
-import { IsString, IsOptional, IsMongoId, MinLength, MaxLength, IsBoolean } from 'class-validator';
+import {
+	IsString,
+	IsOptional,
+	IsMongoId,
+	MinLength,
+	MaxLength,
+	IsBoolean,
+	IsArray,
+} from 'class-validator';
 
 export class CommentResponseDto {
 	@ApiProperty({ description: 'ID của comment' })
@@ -20,6 +28,9 @@ export class CommentResponseDto {
 
 	@ApiProperty({ type: [Types.ObjectId], description: 'Danh sách ID người dùng đã like' })
 	likes: Types.ObjectId[];
+
+	@ApiProperty({ type: [Types.ObjectId], description: 'Danh sách ID người dùng được tag' })
+	taggedUsers: Types.ObjectId[];
 
 	@ApiProperty({ description: 'Trạng thái hoạt động' })
 	isActive: boolean;
@@ -175,4 +186,15 @@ export class UpdateCommentVisibilityDto {
 	})
 	@IsBoolean()
 	isHidden: boolean;
+}
+
+export class TagUsersDto {
+	@ApiProperty({
+		description: 'Danh sách ID người dùng',
+		type: [String],
+		example: ['507f1f77bcf86cd799439011', '507f1f77bcf86cd799439012'],
+	})
+	@IsArray()
+	@IsMongoId({ each: true, message: 'Mỗi ID người dùng phải là MongoDB ObjectId hợp lệ' })
+	userIds: string[];
 }

--- a/src/modules/comment/entities/comment.schema.ts
+++ b/src/modules/comment/entities/comment.schema.ts
@@ -31,6 +31,9 @@ export class Comment extends Document {
 	@Prop({ default: 0, index: true })
 	replyCount: number;
 
+	@Prop({ type: [{ type: Types.ObjectId, ref: 'User' }], default: [] })
+	taggedUsers: Types.ObjectId[];
+
 	createdAt?: Date;
 	updatedAt?: Date;
 }
@@ -42,6 +45,8 @@ CommentSchema.index({ postId: 1, createdAt: -1 });
 CommentSchema.index({ author: 1, createdAt: -1 });
 CommentSchema.index({ parentId: 1, createdAt: -1 });
 CommentSchema.index({ isActive: 1, createdAt: -1 });
+CommentSchema.index({ taggedUsers: 1, createdAt: -1 });
+CommentSchema.index({ isActive: 1, isHidden: 1, taggedUsers: 1 });
 
 // Text search index for comments
 CommentSchema.index({ content: 'text' });

--- a/src/modules/comment/providers/comment.service.ts
+++ b/src/modules/comment/providers/comment.service.ts
@@ -9,6 +9,8 @@ import { Types } from 'mongoose';
 import { I18nContext } from 'nestjs-i18n';
 import { Comment } from '../entities/comment.schema';
 import { Post } from '@modules/post/entities/post.schema';
+import { NotificationService } from '@modules/notification/providers/notification.service';
+import { NotificationType, ReferenceModel } from '@modules/notification/entities/notification.enum';
 import {
 	CreateCommentDto,
 	UpdateCommentDto,
@@ -16,6 +18,7 @@ import {
 	UpdateCommentVisibilityDto,
 	PaginatedCommentsResponseDto,
 	CommentResponseDto,
+	TagUsersDto,
 } from '../dto/comment.dto';
 import {
 	ICommentRepository,
@@ -26,6 +29,7 @@ import {
 export class CommentService {
 	constructor(
 		@Inject(ICommentRepositoryToken) private readonly commentRepository: ICommentRepository,
+		private readonly notificationService: NotificationService,
 	) {}
 
 	async createComment(
@@ -255,5 +259,109 @@ export class CommentService {
 			throw new NotFoundException(i18n.t('comment.POST_NOT_FOUND'));
 		}
 		return this.commentRepository.deleteCommentsByPostId(postId);
+	}
+
+	// Tag users vào comment
+	async tagUsers(
+		commentId: string,
+		authorId: string,
+		tagUsersDto: TagUsersDto,
+		i18n: I18nContext,
+	): Promise<Comment> {
+		const comment = await this.commentRepository.findCommentById(commentId);
+		if (!comment) {
+			throw new NotFoundException(i18n.t('comment.COMMENT_NOT_FOUND'));
+		}
+
+		// Check if user is the author
+		if (comment.author.toString() !== authorId) {
+			throw new ForbiddenException(i18n.t('comment.NOT_AUTHORIZED_TO_UPDATE'));
+		}
+
+		if (!comment.isActive) {
+			throw new BadRequestException(i18n.t('comment.COMMENT_IS_INACTIVE'));
+		}
+
+		// Lấy danh sách taggedUsers cũ để so sánh
+		const oldTagged = (comment.taggedUsers || []).map(id => id.toString());
+
+		// Convert string IDs to ObjectIds
+		const userIds = tagUsersDto.userIds.map(id => new Types.ObjectId(id));
+
+		const updatedComment = await this.commentRepository.tagUsers(commentId, userIds);
+
+		// Tìm những user mới được tag để gửi notification
+		const newTagged = tagUsersDto.userIds.filter(id => !oldTagged.includes(id) && id !== authorId);
+
+		// Gửi notification cho các user mới được tag
+		if (newTagged.length > 0) {
+			await Promise.all(
+				newTagged.map(taggedUserId =>
+					this.notificationService.createNotification({
+						recipient: taggedUserId,
+						sender: authorId,
+						type: NotificationType.MENTION,
+						title: 'You have been tagged in a comment',
+						message: 'You have been tagged in a comment',
+						referenceId: commentId,
+						referenceModel: ReferenceModel.COMMENT,
+					}),
+				),
+			);
+		}
+
+		return updatedComment;
+	}
+
+	// Update toàn bộ danh sách tagged users (thay thế array cũ)
+	async updateTaggedUsers(
+		commentId: string,
+		authorId: string,
+		tagUsersDto: TagUsersDto,
+		i18n: I18nContext,
+	): Promise<Comment> {
+		const comment = await this.commentRepository.findCommentById(commentId);
+		if (!comment) {
+			throw new NotFoundException(i18n.t('comment.COMMENT_NOT_FOUND'));
+		}
+
+		// Check if user is the author
+		if (comment.author.toString() !== authorId) {
+			throw new ForbiddenException(i18n.t('comment.NOT_AUTHORIZED_TO_UPDATE'));
+		}
+
+		if (!comment.isActive) {
+			throw new BadRequestException(i18n.t('comment.COMMENT_IS_INACTIVE'));
+		}
+
+		// Lấy danh sách taggedUsers cũ để so sánh
+		const oldTagged = (comment.taggedUsers || []).map(id => id.toString());
+
+		// Convert string IDs to ObjectIds
+		const userIds = tagUsersDto.userIds.map(id => new Types.ObjectId(id));
+
+		const updatedComment = await this.commentRepository.updateTaggedUsers(commentId, userIds);
+
+		// Tìm những user mới được tag để gửi notification
+		const newTagged = tagUsersDto.userIds.filter(id => !oldTagged.includes(id) && id !== authorId);
+
+		// Gửi notification cho các user mới được tag
+		if (newTagged.length > 0) {
+			await Promise.all(
+				newTagged.map(taggedUserId =>
+					this.notificationService.createNotification({
+						recipient: taggedUserId,
+						sender: authorId,
+						type: NotificationType.MENTION,
+						title: 'You have been tagged in a comment',
+						message: 'You have been tagged in a comment',
+						referenceId: commentId,
+						referenceModel: ReferenceModel.COMMENT,
+					}),
+				),
+			);
+		}
+
+		return updatedComment;
 	}
 }

--- a/src/modules/comment/repositories/comment.repository.impl.ts
+++ b/src/modules/comment/repositories/comment.repository.impl.ts
@@ -184,4 +184,44 @@ export class CommentRepositoryImpl implements ICommentRepository {
 			hasPrevPage: page > 1,
 		};
 	}
+
+	// Tagged users operations
+	async tagUsers(commentId: string, userIds: Types.ObjectId[]): Promise<Comment> {
+		const comment = await this.commentModel.findById(commentId);
+		if (!comment) {
+			throw new Error('Comment not found');
+		}
+
+		// Thêm các user mới vào taggedUsers (tránh duplicate)
+		userIds.forEach(userId => {
+			if (!comment.taggedUsers.some(id => id.equals(userId))) {
+				comment.taggedUsers.push(userId);
+			}
+		});
+
+		await comment.save();
+
+		return comment.populate([
+			{ path: 'authorUser', select: 'firstName lastName avatar' },
+			{ path: 'post', select: 'content' },
+			{ path: 'parentComment', select: 'content author' },
+		]);
+	}
+
+	async updateTaggedUsers(commentId: string, userIds: Types.ObjectId[]): Promise<Comment> {
+		const comment = await this.commentModel.findById(commentId);
+		if (!comment) {
+			throw new Error('Comment not found');
+		}
+
+		// Thay thế toàn bộ danh sách taggedUsers
+		comment.taggedUsers = userIds;
+		await comment.save();
+
+		return comment.populate([
+			{ path: 'authorUser', select: 'firstName lastName avatar' },
+			{ path: 'post', select: 'content' },
+			{ path: 'parentComment', select: 'content author' },
+		]);
+	}
 }

--- a/src/modules/comment/repositories/comment.repository.ts
+++ b/src/modules/comment/repositories/comment.repository.ts
@@ -43,6 +43,10 @@ export interface ICommentRepository {
 	likeComment(commentId: string, userId: Types.ObjectId): Promise<Comment>;
 	unlikeComment(commentId: string, userId: Types.ObjectId): Promise<Comment>;
 
+	// Tagged users operations
+	tagUsers(commentId: string, userIds: Types.ObjectId[]): Promise<Comment>;
+	updateTaggedUsers(commentId: string, userIds: Types.ObjectId[]): Promise<Comment>;
+
 	// Pagination
 	getPaginatedComments(
 		postId: string,


### PR DESCRIPTION
1. POST /comments/:commentId/tag-users
Mô tả: Tag thêm users vào comment
Body: { "userIds": ["userId1", "userId2"] }
Quyền: USER, ADMIN (chỉ tác giả comment)
Notification: ✅ Gửi notification cho user mới được tag

3. PUT /comments/:commentId/tagged-users
Mô tả: Cập nhật toàn bộ danh sách tagged users (thay thế array cũ)
Body: { "userIds": ["userId1", "userId2"] }
Quyền: USER, ADMIN (chỉ tác giả comment)
Notification: ✅ Gửi notification cho user mới được tag